### PR TITLE
Adding close() method to release DB connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var hasBin = require('has-binary-data');
 var msgpack = require('msgpack-js').encode;
 var debug = require('debug')('socket.io-mongodb-emitter');
 var mongodbUri = require('mongodb-uri');
-var util = require('util');
 
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var hasBin = require('has-binary-data');
 var msgpack = require('msgpack-js').encode;
 var debug = require('debug')('socket.io-mongodb-emitter');
 var mongodbUri = require('mongodb-uri');
+var util = require('util');
 
 
 /**
@@ -156,4 +157,14 @@ Emitter.prototype.emit = function(){
   this._flags = {};
 
   return this;
+};
+
+/**
+ * Close the client connection
+ *
+ * @api private
+ */
+
+Emitter.prototype.close = function(){
+  this.client.close();
 };

--- a/index.js
+++ b/index.js
@@ -134,6 +134,14 @@ Emitter.prototype.of = function(nsp) {
 Emitter.prototype.emit = function(){
   // packet
   var args = Array.prototype.slice.call(arguments);
+
+  // isolate callback and remove it from the rest of the data
+  var cb = null;
+  if(args.length === 3){
+    cb = args[2];
+    delete args[2]
+  }
+
   var packet = {};
   packet.type = hasBin(args) ? parser.BINARY_EVENT : parser.EVENT;
   packet.data = args;
@@ -149,7 +157,13 @@ Emitter.prototype.emit = function(){
   this.channel.publish(this.key, { uid: uid, data: msgpack([packet, {
     rooms: this._rooms,
     flags: this._flags
-  }])});
+  }])}, onPublishComplete);
+
+  function onPublishComplete(){
+    if (typeof(cb) === "function") {
+      cb();
+    };
+  };
 
   // reset state
   this._rooms = [];


### PR DESCRIPTION
Thanks for creating this MongoDB Socket.io Emitter library.  

I've added a client.close() method to release the DB connection which was necessary for my application to exit when it completed all other tasks #43dda0a

I've also added a publish callback in #04be100 so that the close() method can be called after the publish is completed.

I hope this is helpful/useful. 

Best,
Lou
