### PR TITLE
streamlined URI passthrough

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,13 @@
 ## How to use
 
 ```js
-var io = require('socket.io-mongodb-emitter')({ host: 'localhost', port: 27017, db: 'test' });
+var io = require('socket.io-mongodb-emitter')('mongodb://localhost:27017');
 setInterval(function(){
   io.emit('time', new Date);
 }, 5000);
 ```
+
+Update 5/31/2017 - Versions prior to 1.0 allowed an object to be passed which was used to build a URI. This caused problems when using replica sets and caused warnings when MongoDB change the client API. In the interest of simplicity and futureproofing the internal URI construction has been eliminated and it is now required that a valid mongo URI be passed.
 
 ## API
 
@@ -20,9 +22,9 @@ setInterval(function(){
 
 `uri` is a string that matches a mongodb connection string
 ```
-mongodb://localhost:27017
+mongodb://localhost:27017/test
 mongodb://user:pass@localhost:27017/test
-localhost:27017
+mongodb://user:pass@host1:27017,host2:27017,host3:27017/test
 ```
 
 ### Emitter(opts)
@@ -30,11 +32,6 @@ localhost:27017
 The following options are allowed:
 
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
-- `host`: host to connect to mongo on (`localhost`)
-- `port`: port to connect to mongo on (`27017`)
-- `db`: db to use in mongo (`mubsub`)
-- `username`: username to connect to mongo with
-- `password`: password to connect to mongo with
 - `socket`: unix domain socket to connect to mongo (`"/tmp/mongo.sock"`). Will
   be used instead of the host and port options if specified.
 - `client`: optional, the mubsub client to publish events on

--- a/index.js
+++ b/index.js
@@ -41,42 +41,10 @@ function Emitter(uri, opts){
   if (!(this instanceof Emitter)) return new Emitter(uri, opts);
   opts = opts || {};
 
-  // handle options only
-  if ('object' == typeof uri) {
-    opts = uri;
-    uri = null;
-  }
-
-  // handle uri string
-  if (uri) {
-
-    // ensure uri has mongodb scheme
-    if (uri.indexOf('mongodb://') !== 0) {
-      uri = 'mongodb://' + uri;
-    }
-
-    // Parse to uri into an object
-    var uriObj = mongodbUri.parse(uri);
-    if (uriObj.username && uriObj.password) {
-      opts.username = uriObj.username;
-      opts.password = uriObj.password;
-    }
-    opts.host = uriObj.hosts[0].host;
-    opts.port = uriObj.hosts[0].port;
-    opts.db = uriObj.database;
-  }
-
-  // opts
-  var socket = opts.socket;
-  var creds = (opts.username && opts.password) ? opts.username + ':' + opts.password + '@' : '';
-  var host = opts.host || '127.0.0.1';
-  var port = Number(opts.port || 27017);
-  var db = opts.db || 'mubsub';
-
   var client = opts.client;
 
   // init clients if needed
-  if (!client) client = socket ? mubsub(socket) : mubsub('mongodb://' + creds + host + ':' + port + '/' + db);
+  if (!client) client = socket ? mubsub(socket) : mubsub(uri);
 
   this.client = client;
   this.key = (opts.key || 'socket.io');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io-mongodb-emitter",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "`socket.io-mongodb-emitter` is an mongodb implementation of `socket-io-emitter`",
   "main": "index.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "has-binary-data": "^0.1.1",
     "uid2": "^0.0.3",
     "socket.io-parser": "^2.2.0",
-    "mubsub": "^1.2.0"
+    "mubsub": "^1.4.0"
   },
   "devDependencies": {},
   "keywords": [
@@ -19,12 +19,13 @@
   ],
   "maintainers": [
     {
-      "name": "Ram"
+      "name": "Lou Klepner",
+      "email": "lklepner@gmail.com"
     }
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ramkumarc/socket.io-mongodb-emitter.git"
+    "url": "https://github.com/lklepner/socket.io-mongodb-emitter.git"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
In the spirit of the socket.io-adapter-mongodb overhaul ( https://github.com/lklepner/socket.io-adapter-mongo ) this PR eliminates internal URI construction in favor of a straight URI passthrough, increments the version number to 1.0.0 to prevent breaking 0.1.x users and updates the documentation to match. 

It also increments the mubsub lib to 1.4.0


