### PR TITLE
bug fix - restoring socket from opts 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
+  - "8"
 
 matrix:
   fast_finish: true

--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ The following options are allowed:
 - `socket`: unix domain socket to connect to mongo (`"/tmp/mongo.sock"`). Will
   be used instead of the host and port options if specified.
 - `client`: optional, the mubsub client to publish events on
+- `mongoOpts`: optional, mongodb connection options. only applicable if URI is used
 
 ### Emitter#to(room:String):Emitter
 ### Emitter#in(room:String):Emitter

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function Emitter(uri, opts){
   if (!(this instanceof Emitter)) return new Emitter(uri, opts);
   opts = opts || {};
 
+  var socket = opts.socket;
   var client = opts.client;
 
   // init clients if needed

--- a/index.js
+++ b/index.js
@@ -41,11 +41,15 @@ function Emitter(uri, opts){
   if (!(this instanceof Emitter)) return new Emitter(uri, opts);
   opts = opts || {};
 
+  // if passed object
+  if (typeof uri == 'object') {
+    opts = uri;
+  }
+
   var socket = opts.socket;
   var client = opts.client;
-
   // init clients if needed
-  if (!client) client = socket ? mubsub(socket) : mubsub(uri);
+  if (!client) client = socket ? mubsub(socket) : mubsub(uri, opts.mongoOpts);
 
   this.client = client;
   this.key = (opts.key || 'socket.io');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io-mongodb-emitter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "`socket.io-mongodb-emitter` is an mongodb implementation of `socket-io-emitter`",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Restoring the ability to pass a DB socket, rather than a URI, which had been inadvertently dropped in the prior update. 

Added opts.mongoOpts to support passing mongo connection options to mubsub