### PR TITLE
Updated socket.io-parser, travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
 
 matrix:
   fast_finish: true
   allow_failures:
+  	- node_js: "0.10"
     - node_js: "0.11"
+    - node_js: "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ node_js:
 matrix:
   fast_finish: true
   allow_failures:
-  	- node_js: "0.10"
+    - node_js: "0.10"
     - node_js: "0.11"
     - node_js: "0.12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io-mongodb-emitter",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "`socket.io-mongodb-emitter` is an mongodb implementation of `socket-io-emitter`",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "debug": "^0.7.4",
     "has-binary-data": "^0.1.1",
     "uid2": "^0.0.3",
-    "socket.io-parser": "^2.2.0",
-    "mubsub": "^1.2.0"
+    "socket.io-parser": "^3.1.0",
+    "mubsub": "^1.4.0"
   },
   "devDependencies": {},
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io-mongodb-emitter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "`socket.io-mongodb-emitter` is an mongodb implementation of `socket-io-emitter`",
   "main": "index.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "has-binary-data": "^0.1.1",
     "uid2": "^0.0.3",
     "socket.io-parser": "^2.2.0",
-    "mubsub": "^1.4.0"
+    "mubsub": "^1.2.0"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
Updated socket.io-parser to 3.1.x, added 0.xx node versions to allowed failure travis tests

Incremented package version to 2.0.0